### PR TITLE
Synchronize java files from downstream bitcoin-s/bitcoin-s repo

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -135,7 +135,6 @@ JAVAORG=org/bitcoin
 JAVA_FILES= \
   $(JAVAROOT)/$(JAVAORG)/NativeSecp256k1.java \
   $(JAVAROOT)/$(JAVAORG)/NativeSecp256k1Test.java \
-  $(JAVAROOT)/$(JAVAORG)/NativeSecp256k1Util.java \
   $(JAVAROOT)/$(JAVAORG)/Secp256k1Context.java
 
 if USE_JNI

--- a/Makefile.am
+++ b/Makefile.am
@@ -134,6 +134,7 @@ JAVAROOT=src/java
 JAVAORG=org/bitcoin
 JAVA_FILES= \
   $(JAVAROOT)/$(JAVAORG)/NativeSecp256k1.java \
+  $(JAVAROOT)/$(JAVAORG)/NativeSecp256k1Util.java \
   $(JAVAROOT)/$(JAVAORG)/NativeSecp256k1Test.java \
   $(JAVAROOT)/$(JAVAORG)/Secp256k1Context.java
 

--- a/src/java/org/bitcoin/NativeSecp256k1Test.java
+++ b/src/java/org/bitcoin/NativeSecp256k1Test.java
@@ -1,11 +1,8 @@
 package org.bitcoin;
 
-import org.junit.Test;
-
 import java.math.BigInteger;
 
-import static org.bitcoin.NativeSecp256k1Util.AssertFailException;
-import static org.bitcoin.NativeSecp256k1Util.assertEquals;
+import static org.bitcoin.NativeSecp256k1Util.*;
 
 /**
  * This class holds test cases defined for testing this library.
@@ -16,8 +13,7 @@ public class NativeSecp256k1Test {
     /**
       * This tests verify() for a valid signature
       */
-    @Test
-    public void testVerifyPos() throws AssertFailException{
+    public static void testVerifyPos() throws AssertFailException{
         byte[] data = toByteArray("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
         byte[] sig = toByteArray("3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589");
         byte[] pub = toByteArray("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
@@ -29,8 +25,7 @@ public class NativeSecp256k1Test {
     /**
       * This tests verify() for a non-valid signature
       */
-    @Test
-    public void testVerifyNeg() throws AssertFailException{
+    public static void testVerifyNeg() throws AssertFailException{
         byte[] data = toByteArray("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A91"); //sha256hash of "testing"
         byte[] sig = toByteArray("3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589");
         byte[] pub = toByteArray("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
@@ -42,8 +37,7 @@ public class NativeSecp256k1Test {
     /**
       * This tests secret key verify() for a valid secretkey
       */
-    @Test
-    public void testSecKeyVerifyPos() throws AssertFailException{
+    public static void testSecKeyVerifyPos() throws AssertFailException{
         byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
 
         boolean result = NativeSecp256k1.secKeyVerify( sec );
@@ -53,8 +47,7 @@ public class NativeSecp256k1Test {
     /**
       * This tests secret key verify() for a invalid secretkey
       */
-    @Test
-    public void testSecKeyVerifyNeg() throws AssertFailException{
+    public static void testSecKeyVerifyNeg() throws AssertFailException{
         byte[] sec = toByteArray("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
 
         boolean result = NativeSecp256k1.secKeyVerify( sec );
@@ -64,8 +57,7 @@ public class NativeSecp256k1Test {
     /**
       * This tests public key create() for a valid secretkey
       */
-    @Test
-    public void testPubKeyCreatePos() throws AssertFailException{
+    public static void testPubKeyCreatePos() throws AssertFailException{
         byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
 
         byte[] resultArr = NativeSecp256k1.computePubkey(sec, false);
@@ -76,8 +68,7 @@ public class NativeSecp256k1Test {
     /**
       * This tests public key create() for a invalid secretkey
       */
-    @Test
-    public void testPubKeyCreateNeg() throws AssertFailException{
+    public static void testPubKeyCreateNeg() throws AssertFailException{
        byte[] sec = toByteArray("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
 
        byte[] resultArr = NativeSecp256k1.computePubkey(sec, false);
@@ -88,8 +79,7 @@ public class NativeSecp256k1Test {
     /**
      * This tests sign() for a valid secretkey
      */
-    @Test
-    public void testSignPos() throws AssertFailException{
+    public static void testSignPos() throws AssertFailException{
 
         byte[] data = toByteArray("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
         byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
@@ -102,8 +92,7 @@ public class NativeSecp256k1Test {
     /**
       * This tests sign() for a invalid secretkey
       */
-    @Test
-    public void testSignNeg() throws AssertFailException{
+    public static void testSignNeg() throws AssertFailException{
         byte[] data = toByteArray("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
         byte[] sec = toByteArray("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
 
@@ -115,8 +104,7 @@ public class NativeSecp256k1Test {
     /**
       * This tests signWithEntropy() for a valid secretkey
       */
-    @Test
-    public void testSignWithEntropyPos() throws AssertFailException{
+    public static void testSignWithEntropyPos() throws AssertFailException{
 
         byte[] data = toByteArray("53702647283D86B3D6410ADEF184EC608372CC3DD8B9202795D731EB1EA54275");
         byte[] sec = toByteArray("B4F62DE42D38D5D24B66FF01761C3FD0A6E7C8B719E0DC54D168FA013BFAF97F");
@@ -130,8 +118,7 @@ public class NativeSecp256k1Test {
     /**
      * This tests signWithEntropy() for a invalid secretkey
      */
-    @Test
-    public void testSignWithEntropyNeg() throws AssertFailException{
+    public static void testSignWithEntropyNeg() throws AssertFailException{
         byte[] data = toByteArray("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
         byte[] sec = toByteArray("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
         byte[] entropy = toByteArray("EDF312C904B610B11442320FFB94C4F976831051A481A17176CE2B81EB3A8B6F");
@@ -144,8 +131,7 @@ public class NativeSecp256k1Test {
     /**
       * This tests private key tweak-add
       */
-    @Test
-    public void testPrivKeyTweakAdd() throws AssertFailException {
+    public static void testPrivKeyTweakAdd() throws AssertFailException {
         byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
         byte[] data = toByteArray("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
 
@@ -157,8 +143,7 @@ public class NativeSecp256k1Test {
     /**
       * This tests private key tweak-mul
       */
-    @Test
-    public void testPrivKeyTweakMul() throws AssertFailException {
+    public static void testPrivKeyTweakMul() throws AssertFailException {
         byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
         byte[] data = toByteArray("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
 
@@ -170,8 +155,7 @@ public class NativeSecp256k1Test {
     /**
       * This tests public key tweak-add
       */
-    @Test
-    public void testPubKeyTweakAdd() throws AssertFailException {
+    public static void testPubKeyTweakAdd() throws AssertFailException {
         byte[] pub = toByteArray("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
         byte[] data = toByteArray("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
 
@@ -186,8 +170,7 @@ public class NativeSecp256k1Test {
     /**
       * This tests public key tweak-mul
       */
-    @Test
-    public void testPubKeyTweakMul() throws AssertFailException {
+    public static void testPubKeyTweakMul() throws AssertFailException {
         byte[] pub = toByteArray("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
         byte[] data = toByteArray("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
 
@@ -202,8 +185,7 @@ public class NativeSecp256k1Test {
     /**
       * This tests seed randomization
       */
-    @Test
-    public void testRandomize() throws AssertFailException {
+    public static void testRandomize() throws AssertFailException {
         byte[] seed = toByteArray("A441B15FE9A3CF56661190A0B93B9DEC7D04127288CC87250967CF3B52894D11"); //sha256hash of "random"
         boolean result = NativeSecp256k1.randomize(seed);
         assertEquals( result, true, "testRandomize");
@@ -213,8 +195,7 @@ public class NativeSecp256k1Test {
      * Tests that we can decompress valid public keys
      * @throws AssertFailException
      */
-    @Test
-    public void testDecompressPubKey() throws AssertFailException {
+    public static void testDecompressPubKey() throws AssertFailException {
         byte[] compressedPubKey = toByteArray("0315EAB529E7D5EB637214EA8EC8ECE5DCD45610E8F4B7CC76A35A6FC27F5DD981");
 
         byte[] result1 = NativeSecp256k1.decompress(compressedPubKey);
@@ -229,8 +210,7 @@ public class NativeSecp256k1Test {
      * Tests that we can check validity of public keys
      * @throws AssertFailException
      */
-    @Test
-    public void testIsValidPubKeyPos() throws AssertFailException {
+    public static void testIsValidPubKeyPos() throws AssertFailException {
         byte[] pubkey = toByteArray("0456b3817434935db42afda0165de529b938cf67c7510168a51b9297b1ca7e4d91ea59c64516373dd2fe6acc79bb762718bc2659fa68d343bdb12d5ef7b9ed002b");
         byte[] compressedPubKey = toByteArray("03de961a47a519c5c0fc8e744d1f657f9ea6b9a921d2a3bceb8743e1885f752676");
 
@@ -239,8 +219,8 @@ public class NativeSecp256k1Test {
         assertEquals(result1, true, "testIsValidPubKeyPos");
         assertEquals(result2, true, "testIsValidPubKeyPos (compressed)");
     }
-    @Test
-    public void testIsValidPubKeyNeg() throws AssertFailException {
+
+    public static void testIsValidPubKeyNeg() throws AssertFailException {
         //do we have test vectors some where to test this more thoroughly?
         byte[] pubkey = toByteArray("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
 
@@ -248,8 +228,8 @@ public class NativeSecp256k1Test {
         assertEquals(result1, false, "testIsValidPubKeyNeg");
     }
 
-    @Test
-    public void testCreateECDHSecret() throws AssertFailException{
+
+    public static void testCreateECDHSecret() throws AssertFailException{
         byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
         byte[] pub = toByteArray("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
 
@@ -281,6 +261,60 @@ public class NativeSecp256k1Test {
             hexChars[j * 2 + 1] = hexArray[v & 0x0F];
         }
         return new String(hexChars);
+    }
+
+    //https://github.com/real-or-random/secp256k1/blob/2abcf951af6a9e8aff7398eb9588a50339b720c7/src/java/org/bitcoin/NativeSecp256k1Test.java#L179
+    //run with 
+    // ./autogen.sh && ./configure --enable-jni --enable-experimental --enable-module-ecdh && make && make check-java
+    public static void main(String[] args) throws AssertFailException{
+
+
+        System.out.println("\n libsecp256k1 enabled: " + Secp256k1Context.isEnabled() + "\n");
+
+        assertEquals( Secp256k1Context.isEnabled(), true, "isEnabled" );
+
+        //Test verify() success/fail
+        testVerifyPos();
+        testVerifyNeg();
+
+        //Test secKeyVerify() success/fail
+        testSecKeyVerifyPos();
+        testSecKeyVerifyNeg();
+
+
+        //Test computePubkey() success/fail
+        testPubKeyCreatePos(); 
+        testPubKeyCreateNeg();
+
+        //Test sign() success/fail
+        testSignPos();
+        testSignNeg();
+
+        testSignWithEntropyPos();
+        testSignWithEntropyNeg();
+
+        //Test privKeyTweakAdd() 1
+        testPrivKeyTweakAdd();
+        testPrivKeyTweakMul();
+
+        testPubKeyTweakAdd();
+        testPubKeyTweakMul();
+
+        //Test randomize()
+        testRandomize();
+
+        testDecompressPubKey();
+
+        testIsValidPubKeyPos();
+        testIsValidPubKeyNeg();
+
+        //Test ECDH
+        testCreateECDHSecret();
+
+        NativeSecp256k1.cleanup();
+
+        System.out.println(" All tests passed." );
+
     }
 
 }

--- a/src/java/org/bitcoin/NativeSecp256k1Test.java
+++ b/src/java/org/bitcoin/NativeSecp256k1Test.java
@@ -1,8 +1,11 @@
 package org.bitcoin;
 
-import javax.xml.bind.DatatypeConverter;
+import org.junit.Test;
 
-import static org.bitcoin.NativeSecp256k1Util.*;
+import java.math.BigInteger;
+
+import static org.bitcoin.NativeSecp256k1Util.AssertFailException;
+import static org.bitcoin.NativeSecp256k1Util.assertEquals;
 
 /**
  * This class holds test cases defined for testing this library.
@@ -13,10 +16,11 @@ public class NativeSecp256k1Test {
     /**
       * This tests verify() for a valid signature
       */
-    public static void testVerifyPos() throws AssertFailException{
-        byte[] data = DatatypeConverter.parseHexBinary("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
-        byte[] sig = DatatypeConverter.parseHexBinary("3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589");
-        byte[] pub = DatatypeConverter.parseHexBinary("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
+    @Test
+    public void testVerifyPos() throws AssertFailException{
+        byte[] data = toByteArray("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
+        byte[] sig = toByteArray("3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589");
+        byte[] pub = toByteArray("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
 
         boolean result = NativeSecp256k1.verify( data, sig, pub);
         assertEquals( result, true , "testVerifyPos");
@@ -25,10 +29,11 @@ public class NativeSecp256k1Test {
     /**
       * This tests verify() for a non-valid signature
       */
-    public static void testVerifyNeg() throws AssertFailException{
-        byte[] data = DatatypeConverter.parseHexBinary("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A91"); //sha256hash of "testing"
-        byte[] sig = DatatypeConverter.parseHexBinary("3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589");
-        byte[] pub = DatatypeConverter.parseHexBinary("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
+    @Test
+    public void testVerifyNeg() throws AssertFailException{
+        byte[] data = toByteArray("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A91"); //sha256hash of "testing"
+        byte[] sig = toByteArray("3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589");
+        byte[] pub = toByteArray("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
 
         boolean result = NativeSecp256k1.verify( data, sig, pub);
         assertEquals( result, false , "testVerifyNeg");
@@ -37,18 +42,20 @@ public class NativeSecp256k1Test {
     /**
       * This tests secret key verify() for a valid secretkey
       */
-    public static void testSecKeyVerifyPos() throws AssertFailException{
-        byte[] sec = DatatypeConverter.parseHexBinary("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
+    @Test
+    public void testSecKeyVerifyPos() throws AssertFailException{
+        byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
 
         boolean result = NativeSecp256k1.secKeyVerify( sec );
         assertEquals( result, true , "testSecKeyVerifyPos");
     }
 
     /**
-      * This tests secret key verify() for an invalid secretkey
+      * This tests secret key verify() for a invalid secretkey
       */
-    public static void testSecKeyVerifyNeg() throws AssertFailException{
-        byte[] sec = DatatypeConverter.parseHexBinary("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+    @Test
+    public void testSecKeyVerifyNeg() throws AssertFailException{
+        byte[] sec = toByteArray("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
 
         boolean result = NativeSecp256k1.secKeyVerify( sec );
         assertEquals( result, false , "testSecKeyVerifyNeg");
@@ -57,112 +64,121 @@ public class NativeSecp256k1Test {
     /**
       * This tests public key create() for a valid secretkey
       */
-    public static void testPubKeyCreatePos() throws AssertFailException{
-        byte[] sec = DatatypeConverter.parseHexBinary("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
+    @Test
+    public void testPubKeyCreatePos() throws AssertFailException{
+        byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
 
         byte[] resultArr = NativeSecp256k1.computePubkey(sec, false);
-        String pubkeyString = DatatypeConverter.printHexBinary(resultArr);
+        String pubkeyString = toHex(resultArr);
         assertEquals( pubkeyString , "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6" , "testPubKeyCreatePos");
     }
 
     /**
       * This tests public key create() for a invalid secretkey
       */
-    public static void testPubKeyCreateNeg() throws AssertFailException{
-       byte[] sec = DatatypeConverter.parseHexBinary("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+    @Test
+    public void testPubKeyCreateNeg() throws AssertFailException{
+       byte[] sec = toByteArray("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
 
        byte[] resultArr = NativeSecp256k1.computePubkey(sec, false);
-       String pubkeyString = DatatypeConverter.printHexBinary(resultArr);
+       String pubkeyString = toHex(resultArr);
        assertEquals( pubkeyString, "" , "testPubKeyCreateNeg");
     }
 
     /**
-      * This tests sign() for a valid secretkey
-      */
-    public static void testSignPos() throws AssertFailException{
+     * This tests sign() for a valid secretkey
+     */
+    @Test
+    public void testSignPos() throws AssertFailException{
 
-        byte[] data = DatatypeConverter.parseHexBinary("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
-        byte[] sec = DatatypeConverter.parseHexBinary("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
+        byte[] data = toByteArray("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
+        byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
 
         byte[] resultArr = NativeSecp256k1.sign(data, sec);
-        String sigString = DatatypeConverter.printHexBinary(resultArr);
+        String sigString = toHex(resultArr);
         assertEquals( sigString, "30440220182A108E1448DC8F1FB467D06A0F3BB8EA0533584CB954EF8DA112F1D60E39A202201C66F36DA211C087F3AF88B50EDF4F9BDAA6CF5FD6817E74DCA34DB12390C6E9" , "testSignPos");
     }
 
     /**
       * This tests sign() for a invalid secretkey
       */
-    public static void testSignNeg() throws AssertFailException{
-        byte[] data = DatatypeConverter.parseHexBinary("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
-        byte[] sec = DatatypeConverter.parseHexBinary("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+    @Test
+    public void testSignNeg() throws AssertFailException{
+        byte[] data = toByteArray("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
+        byte[] sec = toByteArray("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
 
         byte[] resultArr = NativeSecp256k1.sign(data, sec);
-        String sigString = DatatypeConverter.printHexBinary(resultArr);
+        String sigString = toHex(resultArr);
         assertEquals( sigString, "" , "testSignNeg");
     }
 
     /**
-     * This tests signWithEntropy() for a valid secretkey
-     */
-    public static void testSignWithEntropyPos() throws AssertFailException{
+      * This tests signWithEntropy() for a valid secretkey
+      */
+    @Test
+    public void testSignWithEntropyPos() throws AssertFailException{
 
-        byte[] data = DatatypeConverter.parseHexBinary("53702647283D86B3D6410ADEF184EC608372CC3DD8B9202795D731EB1EA54275");
-        byte[] sec = DatatypeConverter.parseHexBinary("B4F62DE42D38D5D24B66FF01761C3FD0A6E7C8B719E0DC54D168FA013BFAF97F");
-        byte[] entropy = DatatypeConverter.parseHexBinary("EDF312C904B610B11442320FFB94C4F976831051A481A17176CE2B81EB3A8B6F");
+        byte[] data = toByteArray("53702647283D86B3D6410ADEF184EC608372CC3DD8B9202795D731EB1EA54275");
+        byte[] sec = toByteArray("B4F62DE42D38D5D24B66FF01761C3FD0A6E7C8B719E0DC54D168FA013BFAF97F");
+        byte[] entropy = toByteArray("EDF312C904B610B11442320FFB94C4F976831051A481A17176CE2B81EB3A8B6F");
 
         byte[] resultArr = NativeSecp256k1.signWithEntropy(data, sec, entropy);
-        String sigString = DatatypeConverter.printHexBinary(resultArr);
+        String sigString = toHex(resultArr);
         assertEquals( sigString, "30450221009D9714BE0CE9A3FD08497125C6D01362FDE2FF118FC817FDB14EE4C38CADFB7A022033B082E161F7D75ABC25642ED71226049DC59EC14AB19DF2A8EFEA47A6C75FAC" , "testSignWithEntropyPos");
     }
 
     /**
      * This tests signWithEntropy() for a invalid secretkey
      */
-    public static void testSignWithEntropyNeg() throws AssertFailException{
-        byte[] data = DatatypeConverter.parseHexBinary("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
-        byte[] sec = DatatypeConverter.parseHexBinary("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
-        byte[] entropy = DatatypeConverter.parseHexBinary("EDF312C904B610B11442320FFB94C4F976831051A481A17176CE2B81EB3A8B6F");
+    @Test
+    public void testSignWithEntropyNeg() throws AssertFailException{
+        byte[] data = toByteArray("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
+        byte[] sec = toByteArray("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+        byte[] entropy = toByteArray("EDF312C904B610B11442320FFB94C4F976831051A481A17176CE2B81EB3A8B6F");
 
         byte[] resultArr = NativeSecp256k1.signWithEntropy(data, sec, entropy);
-        String sigString = DatatypeConverter.printHexBinary(resultArr);
+        String sigString = toHex(resultArr);
         assertEquals( sigString, "" , "testSignWithEntropyNeg");
     }
 
     /**
       * This tests private key tweak-add
       */
-    public static void testPrivKeyTweakAdd() throws AssertFailException {
-        byte[] sec = DatatypeConverter.parseHexBinary("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
-        byte[] data = DatatypeConverter.parseHexBinary("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
+    @Test
+    public void testPrivKeyTweakAdd() throws AssertFailException {
+        byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
+        byte[] data = toByteArray("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
 
         byte[] resultArr = NativeSecp256k1.privKeyTweakAdd( sec , data );
-        String seckeyString = DatatypeConverter.printHexBinary(resultArr);
+        String seckeyString = toHex(resultArr);
         assertEquals( seckeyString , "A168571E189E6F9A7E2D657A4B53AE99B909F7E712D1C23CED28093CD57C88F3" , "testPrivKeyTweakAdd");
     }
 
     /**
       * This tests private key tweak-mul
       */
-    public static void testPrivKeyTweakMul() throws AssertFailException {
-        byte[] sec = DatatypeConverter.parseHexBinary("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
-        byte[] data = DatatypeConverter.parseHexBinary("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
+    @Test
+    public void testPrivKeyTweakMul() throws AssertFailException {
+        byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
+        byte[] data = toByteArray("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
 
         byte[] resultArr = NativeSecp256k1.privKeyTweakMul( sec , data );
-        String seckeyString = DatatypeConverter.printHexBinary(resultArr);
+        String seckeyString = toHex(resultArr);
         assertEquals( seckeyString , "97F8184235F101550F3C71C927507651BD3F1CDB4A5A33B8986ACF0DEE20FFFC" , "testPrivKeyTweakMul");
     }
 
     /**
       * This tests public key tweak-add
       */
-    public static void testPubKeyTweakAdd() throws AssertFailException {
-        byte[] pub = DatatypeConverter.parseHexBinary("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
-        byte[] data = DatatypeConverter.parseHexBinary("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
+    @Test
+    public void testPubKeyTweakAdd() throws AssertFailException {
+        byte[] pub = toByteArray("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
+        byte[] data = toByteArray("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
 
         byte[] resultArr = NativeSecp256k1.pubKeyTweakAdd( pub , data, false);
-        String pubkeyString = DatatypeConverter.printHexBinary(resultArr);
+        String pubkeyString = toHex(resultArr);
         byte[] resultArrCompressed = NativeSecp256k1.pubKeyTweakAdd( pub , data, true);
-        String pubkeyStringCompressed = DatatypeConverter.printHexBinary(resultArrCompressed);
+        String pubkeyStringCompressed = toHex(resultArrCompressed);
         assertEquals(pubkeyString , "0411C6790F4B663CCE607BAAE08C43557EDC1A4D11D88DFCB3D841D0C6A941AF525A268E2A863C148555C48FB5FBA368E88718A46E205FABC3DBA2CCFFAB0796EF" , "testPubKeyTweakAdd");
         assertEquals(pubkeyStringCompressed , "0311C6790F4B663CCE607BAAE08C43557EDC1A4D11D88DFCB3D841D0C6A941AF52" , "testPubKeyTweakAdd (compressed)");
     }
@@ -170,14 +186,15 @@ public class NativeSecp256k1Test {
     /**
       * This tests public key tweak-mul
       */
-    public static void testPubKeyTweakMul() throws AssertFailException {
-        byte[] pub = DatatypeConverter.parseHexBinary("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
-        byte[] data = DatatypeConverter.parseHexBinary("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
+    @Test
+    public void testPubKeyTweakMul() throws AssertFailException {
+        byte[] pub = toByteArray("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
+        byte[] data = toByteArray("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
 
         byte[] resultArr = NativeSecp256k1.pubKeyTweakMul( pub , data, false);
-        String pubkeyString = DatatypeConverter.printHexBinary(resultArr);
+        String pubkeyString = toHex(resultArr);
         byte[] resultArrCompressed = NativeSecp256k1.pubKeyTweakMul( pub , data, true);
-        String pubkeyStringCompressed = DatatypeConverter.printHexBinary(resultArrCompressed);
+        String pubkeyStringCompressed = toHex(resultArrCompressed);
         assertEquals(pubkeyString , "04E0FE6FE55EBCA626B98A807F6CAF654139E14E5E3698F01A9A658E21DC1D2791EC060D4F412A794D5370F672BC94B722640B5F76914151CFCA6E712CA48CC589" , "testPubKeyTweakMul");
         assertEquals(pubkeyStringCompressed , "03E0FE6FE55EBCA626B98A807F6CAF654139E14E5E3698F01A9A658E21DC1D2791" , "testPubKeyTweakMul (compressed)");
     }
@@ -185,8 +202,9 @@ public class NativeSecp256k1Test {
     /**
       * This tests seed randomization
       */
-    public static void testRandomize() throws AssertFailException {
-        byte[] seed = DatatypeConverter.parseHexBinary("A441B15FE9A3CF56661190A0B93B9DEC7D04127288CC87250967CF3B52894D11"); //sha256hash of "random"
+    @Test
+    public void testRandomize() throws AssertFailException {
+        byte[] seed = toByteArray("A441B15FE9A3CF56661190A0B93B9DEC7D04127288CC87250967CF3B52894D11"); //sha256hash of "random"
         boolean result = NativeSecp256k1.randomize(seed);
         assertEquals( result, true, "testRandomize");
     }
@@ -195,13 +213,14 @@ public class NativeSecp256k1Test {
      * Tests that we can decompress valid public keys
      * @throws AssertFailException
      */
-    public static void testDecompressPubKey() throws AssertFailException {
-        byte[] compressedPubKey = DatatypeConverter.parseHexBinary("0315EAB529E7D5EB637214EA8EC8ECE5DCD45610E8F4B7CC76A35A6FC27F5DD981");
+    @Test
+    public void testDecompressPubKey() throws AssertFailException {
+        byte[] compressedPubKey = toByteArray("0315EAB529E7D5EB637214EA8EC8ECE5DCD45610E8F4B7CC76A35A6FC27F5DD981");
 
         byte[] result1 = NativeSecp256k1.decompress(compressedPubKey);
         byte[] result2 = NativeSecp256k1.decompress(result1); // this is a no-op
-        String resultString1 = DatatypeConverter.printHexBinary(result1);
-        String resultString2 = DatatypeConverter.printHexBinary(result2);
+        String resultString1 = toHex(result1);
+        String resultString2 = toHex(result2);
         assertEquals(resultString1, "0415EAB529E7D5EB637214EA8EC8ECE5DCD45610E8F4B7CC76A35A6FC27F5DD9817551BE3DF159C83045D9DFAC030A1A31DC9104082DB7719C098E87C1C4A36C19", "testDecompressPubKey (compressed)");
         assertEquals(resultString2, "0415EAB529E7D5EB637214EA8EC8ECE5DCD45610E8F4B7CC76A35A6FC27F5DD9817551BE3DF159C83045D9DFAC030A1A31DC9104082DB7719C098E87C1C4A36C19", "testDecompressPubKey (no-op)");
     }
@@ -210,85 +229,58 @@ public class NativeSecp256k1Test {
      * Tests that we can check validity of public keys
      * @throws AssertFailException
      */
-    public static void testIsValidPubKeyPos() throws AssertFailException {
-        byte[] pubkey = DatatypeConverter.parseHexBinary("0456b3817434935db42afda0165de529b938cf67c7510168a51b9297b1ca7e4d91ea59c64516373dd2fe6acc79bb762718bc2659fa68d343bdb12d5ef7b9ed002b");
-        byte[] compressedPubKey = DatatypeConverter.parseHexBinary("03de961a47a519c5c0fc8e744d1f657f9ea6b9a921d2a3bceb8743e1885f752676");
+    @Test
+    public void testIsValidPubKeyPos() throws AssertFailException {
+        byte[] pubkey = toByteArray("0456b3817434935db42afda0165de529b938cf67c7510168a51b9297b1ca7e4d91ea59c64516373dd2fe6acc79bb762718bc2659fa68d343bdb12d5ef7b9ed002b");
+        byte[] compressedPubKey = toByteArray("03de961a47a519c5c0fc8e744d1f657f9ea6b9a921d2a3bceb8743e1885f752676");
 
         boolean result1 = NativeSecp256k1.isValidPubKey(pubkey);
         boolean result2 = NativeSecp256k1.isValidPubKey(compressedPubKey);
         assertEquals(result1, true, "testIsValidPubKeyPos");
         assertEquals(result2, true, "testIsValidPubKeyPos (compressed)");
     }
-
-    public static void testIsValidPubKeyNeg() throws AssertFailException {
+    @Test
+    public void testIsValidPubKeyNeg() throws AssertFailException {
         //do we have test vectors some where to test this more thoroughly?
-        byte[] pubkey = DatatypeConverter.parseHexBinary("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+        byte[] pubkey = toByteArray("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
 
         boolean result1 = NativeSecp256k1.isValidPubKey(pubkey);
         assertEquals(result1, false, "testIsValidPubKeyNeg");
     }
 
-    public static void testCreateECDHSecret() throws AssertFailException{
-        byte[] sec = DatatypeConverter.parseHexBinary("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
-        byte[] pub = DatatypeConverter.parseHexBinary("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
+    @Test
+    public void testCreateECDHSecret() throws AssertFailException{
+        byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
+        byte[] pub = toByteArray("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
 
         byte[] resultArr = NativeSecp256k1.createECDHSecret(sec, pub);
-        String ecdhString = DatatypeConverter.printHexBinary(resultArr);
+        String ecdhString = toHex(resultArr);
         assertEquals( ecdhString, "2A2A67007A926E6594AF3EB564FC74005B37A9C8AEF2033C4552051B5C87F043" , "testCreateECDHSecret");
     }
 
-    public static void main(String[] args) throws AssertFailException{
-        
-        System.out.println("\n libsecp256k1 enabled: " + Secp256k1Context.isEnabled() + "\n");
 
-        assertEquals( Secp256k1Context.isEnabled(), true, "isEnabled" );
-
-        //Test verify() success/fail
-        testVerifyPos();
-        testVerifyNeg();
-
-        //Test secKeyVerify() success/fail
-        testSecKeyVerifyPos();
-        testSecKeyVerifyNeg();
-
-        //Test computePubkey() success/fail
-        testPubKeyCreatePos();
-        testPubKeyCreateNeg();
-
-        //Test sign() success/fail
-        testSignPos();
-        testSignNeg();
-
-        //Test signWithEntropy() success/fail
-        testSignWithEntropyPos();
-        testSignWithEntropyNeg();
-
-        //Test privKeyTweakAdd()
-        testPrivKeyTweakAdd();
-
-        //Test privKeyTweakMul()
-        testPrivKeyTweakMul();
-
-        //Test testPubKeyTweakAdd()
-        testPubKeyTweakAdd();
-
-        //Test testPubKeyTweakMul()
-        testPubKeyTweakMul();
-
-        // Test parsing public keys
-        testDecompressPubKey();
-        testIsValidPubKeyPos();
-        testIsValidPubKeyNeg();
-
-        //Test randomize()
-        testRandomize();
-
-        //Test ECDH
-        testCreateECDHSecret();
-
-        NativeSecp256k1.cleanup();
-
-        System.out.println(" All tests passed." );
-
+    //https://stackoverflow.com/a/19119453/967713
+    private static byte[] toByteArray(final String hex) {
+        int len = hex.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(hex.charAt(i), 16) << 4)
+                    + Character.digit(hex.charAt(i+1), 16));
+        }
+        return data;
     }
+
+
+    //https://stackoverflow.com/a/9855338/967713
+    private final static char[] hexArray = "0123456789ABCDEF".toCharArray();
+    public static String toHex(byte[] bytes) {
+        char[] hexChars = new char[bytes.length * 2];
+        for ( int j = 0; j < bytes.length; j++ ) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = hexArray[v >>> 4];
+            hexChars[j * 2 + 1] = hexArray[v & 0x0F];
+        }
+        return new String(hexChars);
+    }
+
 }


### PR DESCRIPTION
This synchronizes java files from downstream in the secp256k1jni project. 

This is needed because java11+ does not support things like `javax.xml` 

It's also a good idea to synchronize in general.

There is one thing that I did not pull down, upstream we've modified [`Secp256k1Context.java`](https://github.com/christewart/bitcoin-s-core/blob/2199cfbb28753385acf1f17c5f4827b15aedb688/secp256k1jni/src/main/java/org/bitcoin/Secp256k1Context.java#L19-L18) to use a new dependency -- the native lib loader for loading static binaries. 

I didn't feel like we should introduce this new dependency in this project. The code that currently exists should have zero java deps. 